### PR TITLE
Fix kv/expire.go partitionID declared and not used

### DIFF
--- a/kv/expire.go
+++ b/kv/expire.go
@@ -41,7 +41,7 @@ func (k *KV) expireKeysFromKV() {
 	defer k.waitGroup.Done()
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
-	partitionID := 0
+	// partitionID := 0
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
# github.com/purak/newton/kv
kv/expire.go:44: partitionID declared and not used